### PR TITLE
fix: add missing cors type definition

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -15,6 +15,7 @@
     "multer": "^1.4.5-lts.1"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.17",
     "@types/express": "^4.17.21",
     "@types/multer": "^1.4.7",
     "@types/node": "^20.12.7",


### PR DESCRIPTION
## Summary
- add the missing `@types/cors` development dependency so the server TypeScript build can resolve cors types

## Testing
- pnpm -C server build
- pnpm -C server test --run

------
https://chatgpt.com/codex/tasks/task_e_68db240ae4fc8328a448b7a57a360573